### PR TITLE
세모이 2014의 flag 값 수정

### DIFF
--- a/hangul/hangulinputcontext-def.h
+++ b/hangul/hangulinputcontext-def.h
@@ -880,7 +880,7 @@ static const HangulKeyboardAddon hangul_keyboard_addon_3_14_proposal = {
 static const HangulKeyboardAddon hangul_keyboard_addon_3moa_semoe_2014 = {
     "3moa-semoe-2014", // id
     0x0000, // replace_it // FALSE
-    0x04, // flag
+    0x00, // flag
     NULL, // symbol_key
     NULL, // symbol_value
     NULL, // (*symbolFunc)(int, int, int)
@@ -897,7 +897,7 @@ static const HangulKeyboardAddon hangul_keyboard_addon_3moa_semoe_2014 = {
 static const HangulKeyboardAddon hangul_keyboard_addon_3moa_semoe_2015 = {
     "3moa-semoe-2015", // id
     0x0000, // replace_it // FALSE
-    0x01, // flag
+    0x00, // flag
     NULL, // symbol_key
     NULL, // symbol_value
     NULL, // (*symbolFunc)(int, int, int)
@@ -931,7 +931,7 @@ static const HangulKeyboardAddon hangul_keyboard_addon_3moa_semoe_2016 = {
 static const HangulKeyboardAddon hangul_keyboard_addon_3sun_2014 = {
     "3sun-2014", // id
     0x0000, // replace_it // FALSE
-    0x01, // flag
+    0x00, // flag
     NULL, // symbol_key
     NULL, // symbol_value
     NULL, // (*symbolFunc)(int, int, int)


### PR DESCRIPTION
안녕하세요, 숨통 님. 이렇게 비공식 구름입력기 1.9.2 버전을 만들어주셔서 감사드립니다.
그리고 세모이 2016 자판의 버그도 해결해 주셔서 정말 감사드립니다.

코드를 확인하다가 세모이 2014 자판에서 입력 순서를 따지지 않게 되어 있는 것을 발견하였습니다.
그래서 이 부분을 수정하다가 확장 배열이 없는 세모이 2015 자판과 새순아래 자판의 flag 값도 함께 수정하여
이렇게 풀 리퀘스트를 드리게 되었습니다.

벌써 이렇게 컴파일 해 주셨는데 번거롭게 해 드려서 죄송합니다...
